### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ This method is sub-par for dependency management (see above notice), but - as a 
 git clone git@github.com:IBT-FMI/SAMRI.git
 cd SAMRI
 mkdir ~/.python_develop
-python setup.py develop --install-dir ~/.python_develop/
 echo "export PYTHONPATH=\$HOME/.python_develop:\$PYTHONPATH" >> ~/.bashrc
 echo "export PATH=\$HOME/.python_develop:\$PATH" >> ~/.bashrc
 source ~/.bashrc
+python setup.py develop --install-dir ~/.python_develop/
 ````
 
 If you are getting a `Permission denied (publickey)` error upon trying to clone, please try pulling via the HTTPS link:


### PR DESCRIPTION
.python_develop has to be added first to path, otherwise the following error

"/usr/lib64/python2.7/site-packages/setuptools/dist.py:345: UserWarning: The version specified ('') is an invalid version, this may not work as expected with newer versions of setuptools, pip, and PyPI. Please see PEP 440 for more details.
  "details." % self.metadata.version
running develop
Checking .pth file support in /home/marksm/.python_develop/
/usr/lib/python-exec/python2.7/python -E -c pass
TEST FAILED: /home/marksm/.python_develop/ does NOT support .pth files
error: bad install directory or PYTHONPATH

You are attempting to install a package to a directory that is not
on PYTHONPATH and which Python does not read ".pth" files from.  The
installation directory you specified (via --install-dir, --prefix, or
the distutils default setting) was:

    /home/marksm/.python_develop/

and your PYTHONPATH environment variable currently contains:

    ''

Here are some of your options for correcting the problem:

* You can choose a different installation directory, i.e., one that is
  on PYTHONPATH or supports .pth files

* You can add the installation directory to the PYTHONPATH environment
  variable.  (It must then also be on PYTHONPATH whenever you run
  Python and want to use the package(s) you are installing.)

* You can set up the installation directory to support ".pth" files by
  using one of the approaches described here:

  https://setuptools.readthedocs.io/en/latest/easy_install.html#custom-installation-locations


Please make the appropriate changes for your system and try again. "