### PR TITLE
rm unnecessary print statements and suppress blender output

### DIFF
--- a/samri/plotting/create_mesh_featuremaps.py
+++ b/samri/plotting/create_mesh_featuremaps.py
@@ -60,10 +60,8 @@ def write_obj(name,verts,faces,normals,values,affine=None,one=False):
 	else :
 		for item in verts:
 			thefile.write("v {0} {1} {2}\n".format(item[0],item[1],item[2]))
-	print("File written 30%")
 	for item in normals:
 		thefile.write("vn {0} {1} {2}\n".format(item[0],item[1],item[2]))
-	print("File written 60%")
 	for item in faces:
 		thefile.write("f {0}//{0} {1}//{1} {2}//{2}\n".format(item[0],item[1],item[2]))
 	thefile.close()
@@ -76,7 +74,6 @@ def create_mesh(stat_map,threshold,
 	img= nibabel.load(stat_map)
 	img_data = img.get_fdata()
 	neg = False
-	print(threshold)
 	#all negative values
 	if (numpy.max(img_data)<= 0):
 		img_data = numpy.absolute(img_data)

--- a/samri/plotting/maps.py
+++ b/samri/plotting/maps.py
@@ -496,7 +496,7 @@ def _create_3Dplot(stat_maps,
 				cli.append(col_plus)
 
 	#python script cannot be run directly, need to start blender in background via command line, then run script.
-	subprocess.run(cli,check=True)
+	subprocess.run(cli,check=True,stdout=open(os.devnull,'wb'))
 
 	mesh = plt.imread("/var/tmp/3Dplot.png")
 
@@ -542,7 +542,7 @@ def _plots_overlay(display,display_3Dplot):
 	#add new axes
 	ax_mesh = fh.add_axes(box)
 
-	#set all backgtuond options to invisible
+	#set all background options to invisible
 	ax_mesh.get_xaxis().set_visible(False)
 	ax_mesh.get_yaxis().set_visible(False)
 	ax_mesh.patch.set_alpha(0.1)
@@ -624,6 +624,7 @@ def stat3D(stat_maps,
 	Identical consequitive statistical maps are auto-detected and share a colorbar.
 	To avoid starting a shared colorbar at the end of a column, please ensure that the length of statistical maps to be plotted is divisible both by the group size and the number of columns.
 	"""
+
 	if isinstance(cut_coords[0],int):
 		print(cut_coords[0])
 		cut_coords=[cut_coords]


### PR DESCRIPTION
I have gotten rid of the print statements. As for
 `subprocess.run(cli,check=True,stdout=open(os.devnull,'wb'))`
this subpresses the output coming from the blender rendering, as there is no direct way to do it via an option within blender. If you think of sth better, please let me know.